### PR TITLE
Remove Mix.get_env from runtime.exs

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,9 +1,3 @@
 import Config
 
-if Mix.env() == :prod do
-  config :miser, Miser, YamlElixir.read_from_file!("/config/config.yml")
-else
-  config :miser, Miser, %{
-    project_id: "my-project"
-  }
-end
+config :miser, Miser, YamlElixir.read_from_file!("/config/config.yml")

--- a/lib/miser/collector.ex
+++ b/lib/miser/collector.ex
@@ -20,11 +20,11 @@ defmodule Miser.Collector do
   @spec collect_mf(any, any) :: :ok
   def collect_mf(_registry, callback) do
     config = Application.get_env(:miser, Miser)
-    project_id = Map.fetch!(config, :project_id)
-    user_labels = Map.get(config, :user_labels, %{})
+    project_id = Map.fetch!(config, "project_id")
+    user_labels = Map.get(config, "user_labels", %{})
 
     config
-    |> Map.get(:metric_type_prefixes, [])
+    |> Map.get("metric_type_prefixes", [])
     # should probably parallelize this
     |> Enum.each(fn metric_type_prefix ->
       request = %ListMetricDescriptorsRequest{


### PR DESCRIPTION
Not available in runtime.

Need a better setup for running locally.

This'll unblock getting the docker image pushed.